### PR TITLE
Add delete functionality for transactions, accounts, and budget categories

### DIFF
--- a/server/app/graphql/mutations/delete_account.rb
+++ b/server/app/graphql/mutations/delete_account.rb
@@ -1,0 +1,34 @@
+module Mutations
+  class DeleteAccount < BaseMutation
+    argument :id, ID, required: true
+
+    field :success, Boolean, null: false
+    field :errors, [String], null: false
+
+    def resolve(id:)
+      account = Account.find(id)
+      user = context[:current_user] or raise GraphQL::ExecutionError, "Unauthorized"
+
+      if account.user != user
+        raise GraphQL::ExecutionError, "Unauthorized"
+      end
+
+      if account.destroy
+        {
+          success: true,
+          errors: []
+        }
+      else
+        {
+          success: false,
+          errors: account.errors.full_messages
+        }
+      end
+    rescue ActiveRecord::RecordNotFound
+      {
+        success: false,
+        errors: ["Account not found"]
+      }
+    end
+  end
+end

--- a/server/app/graphql/mutations/delete_budget_category.rb
+++ b/server/app/graphql/mutations/delete_budget_category.rb
@@ -1,0 +1,34 @@
+module Mutations
+  class DeleteBudgetCategory < BaseMutation
+    argument :id, ID, required: true
+
+    field :success, Boolean, null: false
+    field :errors, [String], null: false
+
+    def resolve(id:)
+      budget_category = BudgetCategory.find(id)
+      user = context[:current_user] or raise GraphQL::ExecutionError, "Unauthorized"
+
+      if budget_category.user != user
+        raise GraphQL::ExecutionError, "Unauthorized"
+      end
+
+      if budget_category.destroy
+        {
+          success: true,
+          errors: []
+        }
+      else
+        {
+          success: false,
+          errors: budget_category.errors.full_messages
+        }
+      end
+    rescue ActiveRecord::RecordNotFound
+      {
+        success: false,
+        errors: ["Budget category not found"]
+      }
+    end
+  end
+end

--- a/server/app/graphql/mutations/delete_transaction.rb
+++ b/server/app/graphql/mutations/delete_transaction.rb
@@ -1,0 +1,34 @@
+module Mutations
+  class DeleteTransaction < BaseMutation
+    argument :id, ID, required: true
+
+    field :success, Boolean, null: false
+    field :errors, [String], null: false
+
+    def resolve(id:)
+      transaction = Transaction.find(id)
+      user = context[:current_user] or raise GraphQL::ExecutionError, "Unauthorized"
+
+      if transaction.account.user != user
+        raise GraphQL::ExecutionError, "Unauthorized"
+      end
+
+      if transaction.destroy
+        {
+          success: true,
+          errors: []
+        }
+      else
+        {
+          success: false,
+          errors: transaction.errors.full_messages
+        }
+      end
+    rescue ActiveRecord::RecordNotFound
+      {
+        success: false,
+        errors: ["Transaction not found"]
+      }
+    end
+  end
+end

--- a/server/app/graphql/types/mutation_type.rb
+++ b/server/app/graphql/types/mutation_type.rb
@@ -4,7 +4,10 @@ module Types
   class MutationType < Types::BaseObject
     field :create_account, mutation: Mutations::CreateAccount
     field :update_account, mutation: Mutations::UpdateAccount
+    field :delete_account, mutation: Mutations::DeleteAccount
     field :create_budget_category, mutation: Mutations::CreateBudgetCategory
+    field :delete_budget_category, mutation: Mutations::DeleteBudgetCategory
     field :create_transaction, mutation: Mutations::CreateTransaction
+    field :delete_transaction, mutation: Mutations::DeleteTransaction
   end
 end

--- a/web/src/components/BudgetCategoryList.tsx
+++ b/web/src/components/BudgetCategoryList.tsx
@@ -1,5 +1,6 @@
-import { useQuery } from "@apollo/client";
+import { useQuery, useMutation } from "@apollo/client";
 import { GET_BUDGET_CATEGORIES } from "../graphql/queries";
+import { DELETE_BUDGET_CATEGORY } from "../graphql/mutations";
 
 interface Transaction {
   id: string;
@@ -26,7 +27,29 @@ interface BudgetCategoryListProps {
 export function BudgetCategoryList({
   onCategoryClick,
 }: BudgetCategoryListProps) {
-  const { loading, error, data } = useQuery(GET_BUDGET_CATEGORIES);
+  const { loading, error, data, refetch } = useQuery(GET_BUDGET_CATEGORIES);
+  const [deleteBudgetCategory] = useMutation(DELETE_BUDGET_CATEGORY);
+
+  const handleDeleteBudgetCategory = async (
+    categoryId: string,
+    categoryName: string
+  ) => {
+    if (
+      window.confirm(
+        `Are you sure you want to delete the budget category "${categoryName}"?`
+      )
+    ) {
+      try {
+        await deleteBudgetCategory({
+          variables: { id: categoryId },
+        });
+        refetch();
+      } catch (error) {
+        console.error("Error deleting budget category:", error);
+        alert("Failed to delete budget category");
+      }
+    }
+  };
 
   if (loading) return <p>Loading budget categories...</p>;
   if (error) {
@@ -59,16 +82,26 @@ export function BudgetCategoryList({
                 onClick={() => onCategoryClick(category.id)}
                 style={{ cursor: "pointer" }}
               >
-                <h3>
-                  {category.name}
-                  <span
-                    className={`category-type-badge ${category.categoryType}`}
+                <div className="flex justify-between items-start">
+                  <h3>
+                    {category.name}
+                    <span
+                      className={`category-type-badge ${category.categoryType}`}
+                    >
+                      {category.categoryType.replace("_", " ").toUpperCase()}
+                    </span>
+                  </h3>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDeleteBudgetCategory(category.id, category.name);
+                    }}
+                    className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 p-1 rounded transition-colors duration-150 text-xs"
+                    title="Delete budget category"
                   >
-                    {category.categoryType === "variable_expense" && "💸"}
-                    {category.categoryType === "debt_repayment" && "💳"}
-                    {category.categoryType.replace("_", " ").toUpperCase()}
-                  </span>
-                </h3>
+                    ×
+                  </button>
+                </div>
 
                 <div className="category-amounts">
                   <p className="budget-amount">

--- a/web/src/graphql/mutations.ts
+++ b/web/src/graphql/mutations.ts
@@ -107,3 +107,30 @@ export const CREATE_TRANSACTION = gql`
     }
   }
 `;
+
+export const DELETE_ACCOUNT = gql`
+  mutation DeleteAccount($id: ID!) {
+    deleteAccount(input: { id: $id }) {
+      success
+      errors
+    }
+  }
+`;
+
+export const DELETE_BUDGET_CATEGORY = gql`
+  mutation DeleteBudgetCategory($id: ID!) {
+    deleteBudgetCategory(input: { id: $id }) {
+      success
+      errors
+    }
+  }
+`;
+
+export const DELETE_TRANSACTION = gql`
+  mutation DeleteTransaction($id: ID!) {
+    deleteTransaction(input: { id: $id }) {
+      success
+      errors
+    }
+  }
+`;


### PR DESCRIPTION
Fixes: https://github.com/gnarlyn8/budget-tracker/issues/10

Delete account:
<img width="1216" height="404" alt="Screenshot 2025-08-17 at 4 35 46 PM" src="https://github.com/user-attachments/assets/6ccd9843-aced-4774-8fc4-6b2877024264" />

Delete transaction (x)
<img width="1216" height="245" alt="Screenshot 2025-08-17 at 4 36 13 PM" src="https://github.com/user-attachments/assets/87ba2960-7f87-4e42-bcf9-4e05ebbb4e36" />

While building this functionality, I noticed that I don't show the current budget categories yet, so I created a new issue for that [here](https://github.com/gnarlyn8/budget-tracker/issues/12)
