### PR TITLE
Update styles for login and signup forms

### DIFF
--- a/web/src/components/LoginForm.tsx
+++ b/web/src/components/LoginForm.tsx
@@ -31,11 +31,18 @@ export function LoginForm({
   };
 
   return (
-    <div className="auth-form">
-      <h2>Login</h2>
+    <div className="w-full bg-gray-800 border border-gray-700 rounded-xl p-8 shadow-md">
+      <h2 className="text-gray-100 text-xl font-semibold mb-6 text-center">
+        Login
+      </h2>
       <form onSubmit={handleSubmit}>
-        <div className="form-group">
-          <label htmlFor="email">Email:</label>
+        <div className="mb-6">
+          <label
+            htmlFor="email"
+            className="block mb-2 text-gray-300 font-medium"
+          >
+            Email:
+          </label>
           <input
             type="email"
             id="email"
@@ -44,11 +51,17 @@ export function LoginForm({
             required
             disabled={loading}
             placeholder="Enter your email"
+            className="w-full p-3 border-2 border-gray-600 rounded-lg text-base transition-colors duration-300 box-border bg-gray-700 text-gray-100 focus:outline-none focus:border-purple-500"
           />
         </div>
 
-        <div className="form-group">
-          <label htmlFor="password">Password:</label>
+        <div className="mb-6">
+          <label
+            htmlFor="password"
+            className="block mb-2 text-gray-300 font-medium"
+          >
+            Password:
+          </label>
           <input
             type="password"
             id="password"
@@ -57,21 +70,26 @@ export function LoginForm({
             required
             disabled={loading}
             placeholder="Enter your password"
+            className="w-full p-3 border-2 border-gray-600 rounded-lg text-base transition-colors duration-300 box-border bg-gray-700 text-gray-100 focus:outline-none focus:border-purple-500"
           />
         </div>
 
-        <button type="submit" disabled={loading}>
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full p-4 bg-purple-500 text-white border-none rounded-lg text-base font-medium cursor-pointer transition-colors duration-300 hover:bg-purple-600 disabled:bg-gray-500 disabled:cursor-not-allowed"
+        >
           {loading ? "Logging in..." : "Login"}
         </button>
 
-        {error && <p className="error">{error}</p>}
+        {error && <p className="text-red-400 mt-4 text-center">{error}</p>}
 
-        <p className="auth-switch">
+        <p className="text-center text-sm text-gray-400 mt-4">
           Don't have an account?{" "}
           <button
             type="button"
             onClick={onSwitchToSignup}
-            className="link-button"
+            className="text-purple-400 hover:text-purple-300 font-medium focus:outline-none focus:underline"
           >
             Sign up
           </button>

--- a/web/src/components/SignupForm.tsx
+++ b/web/src/components/SignupForm.tsx
@@ -38,11 +38,18 @@ export function SignupForm({
   };
 
   return (
-    <div className="auth-form">
-      <h2>Sign Up</h2>
+    <div className="w-full bg-gray-800 border border-gray-700 rounded-xl p-8 shadow-md">
+      <h2 className="text-gray-100 text-xl font-semibold mb-6 text-center">
+        Sign Up
+      </h2>
       <form onSubmit={handleSubmit}>
-        <div className="form-group">
-          <label htmlFor="email">Email:</label>
+        <div className="mb-6">
+          <label
+            htmlFor="email"
+            className="block mb-2 text-gray-300 font-medium"
+          >
+            Email:
+          </label>
           <input
             type="email"
             id="email"
@@ -51,11 +58,17 @@ export function SignupForm({
             required
             disabled={loading}
             placeholder="Enter your email"
+            className="w-full p-3 border-2 border-gray-600 rounded-lg text-base transition-colors duration-300 box-border bg-gray-700 text-gray-100 focus:outline-none focus:border-purple-500"
           />
         </div>
 
-        <div className="form-group">
-          <label htmlFor="password">Password:</label>
+        <div className="mb-6">
+          <label
+            htmlFor="password"
+            className="block mb-2 text-gray-300 font-medium"
+          >
+            Password:
+          </label>
           <input
             type="password"
             id="password"
@@ -64,11 +77,17 @@ export function SignupForm({
             required
             disabled={loading}
             placeholder="Enter your password"
+            className="w-full p-3 border-2 border-gray-600 rounded-lg text-base transition-colors duration-300 box-border bg-gray-700 text-gray-100 focus:outline-none focus:border-purple-500"
           />
         </div>
 
-        <div className="form-group">
-          <label htmlFor="passwordConfirmation">Confirm Password:</label>
+        <div className="mb-6">
+          <label
+            htmlFor="passwordConfirmation"
+            className="block mb-2 text-gray-300 font-medium"
+          >
+            Confirm Password:
+          </label>
           <input
             type="password"
             id="passwordConfirmation"
@@ -77,21 +96,26 @@ export function SignupForm({
             required
             disabled={loading}
             placeholder="Confirm your password"
+            className="w-full p-3 border-2 border-gray-600 rounded-lg text-base transition-colors duration-300 box-border bg-gray-700 text-gray-100 focus:outline-none focus:border-purple-500"
           />
         </div>
 
-        <button type="submit" disabled={loading}>
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full p-4 bg-purple-500 text-white border-none rounded-lg text-base font-medium cursor-pointer transition-colors duration-300 hover:bg-purple-600 disabled:bg-gray-500 disabled:cursor-not-allowed"
+        >
           {loading ? "Creating account..." : "Sign Up"}
         </button>
 
-        {error && <p className="error">{error}</p>}
+        {error && <p className="text-red-400 mt-4 text-center">{error}</p>}
 
-        <p className="auth-switch">
+        <p className="text-center text-sm text-gray-400 mt-4">
           Already have an account?{" "}
           <button
             type="button"
             onClick={onSwitchToLogin}
-            className="link-button"
+            className="text-purple-400 hover:text-purple-300 font-medium focus:outline-none focus:underline"
           >
             Login
           </button>


### PR DESCRIPTION
Fixes: https://github.com/gnarlyn8/budget-tracker/issues/28

Now the login and signup forms look WAY better, and more aligned with the other styles from the app.

Login:
<img width="1223" height="655" alt="Screenshot 2025-08-18 at 5 45 00 PM" src="https://github.com/user-attachments/assets/9edd0cdd-9d51-4f13-ba35-c05d09f079a9" />

Signup:
<img width="1223" height="785" alt="Screenshot 2025-08-18 at 5 45 22 PM" src="https://github.com/user-attachments/assets/1cf7c063-7110-4d0d-a437-da6854fe3b55" />
