### PR TITLE
Update space between titles and content

### DIFF
--- a/web/src/components/AccountsPage.tsx
+++ b/web/src/components/AccountsPage.tsx
@@ -25,7 +25,7 @@ export function AccountsPage({ onAccountClick }: AccountsPageProps) {
 
   return (
     <div className="space-y-6">
-      <div>
+      <div className="space-y-6">
         <h1 className="text-gray-800 dark:text-white text-3xl font-bold text-center">
           Your Accounts
         </h1>

--- a/web/src/components/BudgetCategoriesPage.tsx
+++ b/web/src/components/BudgetCategoriesPage.tsx
@@ -21,7 +21,7 @@ export function BudgetCategoriesPage() {
 
   return (
     <div className="space-y-6">
-      <div>
+      <div className="space-y-6">
         <h1 className="text-gray-800 dark:text-white text-3xl font-bold text-center">
           Budget Categories
         </h1>


### PR DESCRIPTION
Fixes: https://github.com/gnarlyn8/budget-tracker/issues/20

The content and titles now have a space that is equivalent to forms, which makes the app feel a little more uniform now.

Account transactions:
<img width="1223" height="716" alt="Screenshot 2025-08-18 at 6 33 04 PM" src="https://github.com/user-attachments/assets/355332d9-dfea-42e3-a337-3f28cab2fa1e" />

Titles:
<img width="1223" height="716" alt="Screenshot 2025-08-18 at 6 33 15 PM" src="https://github.com/user-attachments/assets/6914f20d-9db5-444d-b5c6-3e83405276b0" />
