### PR TITLE
Fix Bug in budget category ledger and related transaction method

### DIFF
--- a/server/app/graphql/mutations/delete_transaction.rb
+++ b/server/app/graphql/mutations/delete_transaction.rb
@@ -48,8 +48,9 @@ module Mutations
           accounts: { account_type: "loan", user: transaction.account.user },
           occurred_on: transaction.occurred_on,
           memo: transaction.memo,
-          amount_cents: transaction.amount_cents.abs,
-          budget_category: transaction.budget_category
+          amount_cents: transaction.amount_cents.abs
+        ).where(
+          budget_category: [transaction.budget_category, nil]
         ).first
       else
         Transaction.where(

--- a/server/app/graphql/mutations/delete_transaction.rb
+++ b/server/app/graphql/mutations/delete_transaction.rb
@@ -48,7 +48,8 @@ module Mutations
           accounts: { account_type: "loan", user: transaction.account.user },
           occurred_on: transaction.occurred_on,
           memo: transaction.memo,
-          amount_cents: transaction.amount_cents.abs
+          amount_cents: transaction.amount_cents.abs,
+          budget_category: transaction.budget_category
         ).first
       else
         Transaction.where(

--- a/server/app/graphql/types/query_type.rb
+++ b/server/app/graphql/types/query_type.rb
@@ -41,7 +41,7 @@ module Types
 
     def account(id:)
       user = context[:current_user] or raise GraphQL::ExecutionError, "Unauthorized"
-      user.accounts.includes(:transactions).find(id)
+      user.accounts.includes(transactions: :budget_category).find(id)
     end
 
     field :budget_categories, [Types::BudgetCategoryType], null: false,
@@ -49,7 +49,7 @@ module Types
 
     def budget_categories
       user = context[:current_user] or raise GraphQL::ExecutionError, "Unauthorized"
-      user.budget_categories.includes(:transactions).all
+      user.budget_categories.includes(transactions: :account).all
     end
 
     field :budget_category, Types::BudgetCategoryType, null: true do
@@ -57,7 +57,7 @@ module Types
     end
 
     def budget_category(id:)
-      BudgetCategory.includes(:transactions).find(id)
+      BudgetCategory.includes(transactions: :account).find(id)
     end
 
     field :transactions, [Types::TransactionType], null: false,

--- a/server/app/services/ledger.rb
+++ b/server/app/services/ledger.rb
@@ -23,6 +23,7 @@ class Ledger
 
       Transaction.create!(
         account: loan,
+        budget_category_id: category.id,
         amount_cents: amount_cents,  
         occurred_on: on,
         memo: memo

--- a/web/src/test/utils.tsx
+++ b/web/src/test/utils.tsx
@@ -1,6 +1,6 @@
 import { MockedProvider } from "@apollo/client/testing";
-import { render, RenderOptions } from "@testing-library/react";
-import { ReactElement } from "react";
+import { render, type RenderOptions } from "@testing-library/react";
+import type { ReactElement } from "react";
 
 interface CustomRenderOptions extends Omit<RenderOptions, "wrapper"> {
   mocks?: any[];


### PR DESCRIPTION
I noticed a bug while adding some tests to the account and account list components, so I decided to fix that. Now the budget category is included in all types of loans when the transactions are created in the ledger, and the related transactions are removed from both accounts so you don't have to delete them individually. 

This code is technically fine, but should be merged after the tests just because this branch is based off of that.